### PR TITLE
Use grep to extract runtime line in plotting script

### DIFF
--- a/make_plots.sh
+++ b/make_plots.sh
@@ -14,7 +14,7 @@ printf "size,version,time_ms\n" > "$out_file"
 
 for n in "${sizes[@]}"; do
   for v in r c s; do
-    line=$(./prog -$v $n $k | tail -n1)
+    line=$(./prog -$v $n $k | grep 'Average runtime')
     time_ms=$(echo "$line" | awk '{print $(NF-1)}')
     printf "%s,%s,%s\n" "$n" "$v" "$time_ms" >> "$out_file"
   done


### PR DESCRIPTION
## Summary
- Capture the "Average runtime" line using `grep` in `make_plots.sh`
- Continue to extract the runtime value in milliseconds for the CSV

## Testing
- `./make_plots.sh` *(fails: ModuleNotFoundError: No module named 'matplotlib')*

------
https://chatgpt.com/codex/tasks/task_e_68a5a87028d08323a7a051e396acac4a