### PR TITLE
Handle invalid time values in plot_results

### DIFF
--- a/plot_results.py
+++ b/plot_results.py
@@ -15,7 +15,12 @@ with open(csv_path) as f:
     reader = csv.DictReader(f)
     for row in reader:
         size = int(row['size'])
-        data[size][row['version']] = float(row['time_ms'])
+        try:
+            time_ms = float(row['time_ms'])
+        except ValueError:
+            print(f"Warning: skipping row with non-numeric time_ms={row['time_ms']!r}", file=sys.stderr)
+            continue
+        data[size][row['version']] = time_ms
 
 sizes = sorted(data.keys())
 row = [data[n].get('r', 0) for n in sizes]


### PR DESCRIPTION
## Summary
- tolerate non-numeric `time_ms` values when parsing CSV results
- warn and skip entries with invalid timings instead of crashing

## Testing
- ⚠️ `python3 plot_results.py bad_results.csv` (stubbed matplotlib)

------
https://chatgpt.com/codex/tasks/task_e_68a5a8729ff483239af6463b52f89bd5