### PR TITLE
Remove size parameter from convolution helpers

### DIFF
--- a/main.c
+++ b/main.c
@@ -55,24 +55,24 @@ int main(int argc, char* argv[]) {
     switch (argv[1][1]) {
         case 'r':
             printf("Benchmarking row-major convolution...\n");
-            benchmark(convolve_row_major, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_row_major, matrix, kernel, output, k, out_size);
             break;
         case 'c':
             printf("Benchmarking column-major convolution...\n");
-            benchmark(convolve_col_major, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_col_major, matrix, kernel, output, k, out_size);
             break;
         case 's':
             printf("Benchmarking SIMD convolution...\n");
-            benchmark(convolve_simd, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_simd, matrix, kernel, output, k, out_size);
             break;
         case 'a':
             printf("All convolutions will be benchmarked.\n");
             printf("Benchmarking row-major convolution...\n");
-            benchmark(convolve_row_major, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_row_major, matrix, kernel, output, k, out_size);
             printf("Benchmarking column-major convolution...\n");
-            benchmark(convolve_col_major, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_col_major, matrix, kernel, output, k, out_size);
             printf("Benchmarking SIMD convolution...\n");
-            benchmark(convolve_simd, matrix, kernel, output, n, k, out_size);
+            benchmark(convolve_simd, matrix, kernel, output, k, out_size);
             break;
         default:
                 fprintf(stderr, "Usage: ./prog [-r|-c|-s|-a] <size> <kernel> \n -r: Row-major convolution \n -c: Column-major convolution \n -s: SIMD convolution \n -a: All convolutions \n");

--- a/matrix.c
+++ b/matrix.c
@@ -41,7 +41,7 @@ float** kxk(int k) {
 }
 
 float** convolve_row_major(float** matrix, float** kernel,float** output,
-                           int n, int k,int out_size){
+                           int k,int out_size){
     // Convolution (row-major)
     for (int i = 0; i < out_size; i++) {
         for (int j = 0; j < out_size; j++) {
@@ -62,7 +62,7 @@ float** convolve_row_major(float** matrix, float** kernel,float** output,
 
 
 float** convolve_col_major(float** matrix, float** kernel,float** output,
-                           int n, int k,int out_size){
+                           int k,int out_size){
 
     // Convolution (col-major)
     for (int j = 0; j < out_size; j++) {
@@ -82,7 +82,7 @@ float** convolve_col_major(float** matrix, float** kernel,float** output,
 
 
 float** convolve_simd(float** matrix, float** kernel,float** output,
-                      int n, int k,int out_size){
+                      int k,int out_size){
 
     for (int i = 0; i < out_size; i++) {
         for (int j = 0; j < out_size; j++) {

--- a/matrix.h
+++ b/matrix.h
@@ -5,10 +5,10 @@ float** nxn(int n);
 float** kxk(int k);
 
 float** convolve_row_major(float** matrix, float** kernel,float** output,
-                        int n, int k,int out_size);
+                        int k,int out_size);
 float** convolve_col_major(float** matrix, float** kernel,float** output,
-                        int n, int k,int out_size);
+                        int k,int out_size);
 float** convolve_simd(float** matrix, float** kernel,float** output,
-                   int n, int k,int out_size);
+                   int k,int out_size);
  
 #endif

--- a/utils.c
+++ b/utils.c
@@ -30,9 +30,9 @@ void clear_matrix(float** matrix, int n) {
     }
 }
 
-void benchmark(float** (*fun)(float**, float**,float**, int, int, int),
+void benchmark(float** (*fun)(float**, float**,float**, int, int),
                float** matrix, float** kernel,float** output,
-               int n, int k, int out_size) {
+               int k, int out_size) {
     const int repeats = 5;
     double total_ms = 0.0;
 
@@ -40,7 +40,7 @@ void benchmark(float** (*fun)(float**, float**,float**, int, int, int),
         struct timespec start, end;
         clear_matrix(output, out_size);
         clock_gettime(CLOCK_MONOTONIC, &start);
-        output = fun(matrix, kernel, output, n, k, out_size);
+        output = fun(matrix, kernel, output, k, out_size);
         clock_gettime(CLOCK_MONOTONIC, &end);
         long seconds = end.tv_sec - start.tv_sec;
         long nanoseconds = end.tv_nsec - start.tv_nsec;

--- a/utils.h
+++ b/utils.h
@@ -4,7 +4,7 @@
 void print_matrix(float **matrix, int n);
 void free_matrix(float **matrix, int n);
 void clear_matrix(float** matrix, int n);
-void benchmark(float** (*fun) (float**, float**,float**, int, int, int),
+void benchmark(float** (*fun) (float**, float**,float**, int, int),
                float** matrix, float** kernel,float** output,
-               int n, int k, int out_size);
+               int k, int out_size);
 #endif


### PR DESCRIPTION
## Summary
- drop unused `n` argument from `convolve_row_major`, `convolve_col_major` and `convolve_simd`
- update benchmark function pointer and call sites to match new signatures
- rebuild project to ensure clean compilation

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a5a86c3118832397c469e59917f2ef