### PR TITLE
Add malloc failure handling for matrices

### DIFF
--- a/main.c
+++ b/main.c
@@ -41,14 +41,39 @@ int main(int argc, char* argv[]) {
 
     //Initialize matrices and kernels
     float** matrix = nxn(n);
+    if (!matrix) {
+        fprintf(stderr, "Failed to allocate matrix.\n");
+        return 1;
+    }
     float** kernel = kxk(k);
+    if (!kernel) {
+        fprintf(stderr, "Failed to allocate kernel.\n");
+        free_matrix(matrix, n);
+        return 1;
+    }
 
     int out_size = n - k + 1;
-    
+
     // Allocation de la matrice de sortie
     float** output = malloc(out_size * sizeof(float*));
+    if (!output) {
+        fprintf(stderr, "Failed to allocate output matrix.\n");
+        free_matrix(matrix, n);
+        free_matrix(kernel, k);
+        return 1;
+    }
     for (int i = 0; i < out_size; i++) {
         output[i] = malloc(out_size * sizeof(float));
+        if (!output[i]) {
+            for (int j = 0; j < i; j++) {
+                free(output[j]);
+            }
+            free(output);
+            free_matrix(matrix, n);
+            free_matrix(kernel, k);
+            fprintf(stderr, "Failed to allocate output matrix.\n");
+            return 1;
+        }
     }
     clear_matrix(output, out_size);
 

--- a/matrix.c
+++ b/matrix.c
@@ -4,11 +4,20 @@
 #include <immintrin.h>
 
 float** nxn(int n) {
-
     float** matrice = malloc(n * sizeof(float*));
+    if (!matrice) {
+        return NULL;
+    }
 
     for (int i = 0; i < n; i++) {
         matrice[i] = malloc(n * sizeof(float));
+        if (!matrice[i]) {
+            for (int j = 0; j < i; j++) {
+                free(matrice[j]);
+            }
+            free(matrice);
+            return NULL;
+        }
     }
 
     for (int i = 0; i < n; i++) {
@@ -16,18 +25,27 @@ float** nxn(int n) {
             matrice[i][j] = rand() / (float)RAND_MAX;
         }
     }
+
     return matrice;
-
-
 }
 
 float** kxk(int k) {
-
     float** matrice = malloc(k * sizeof(float*));
+    if (!matrice) {
+        return NULL;
+    }
+
     float value = 1.0 / (k * k);
 
     for (int i = 0; i < k; i++) {
         matrice[i] = malloc(k * sizeof(float));
+        if (!matrice[i]) {
+            for (int j = 0; j < i; j++) {
+                free(matrice[j]);
+            }
+            free(matrice);
+            return NULL;
+        }
     }
 
     for (int i = 0; i < k; i++) {
@@ -35,9 +53,8 @@ float** kxk(int k) {
             matrice[i][j] = value;
         }
     }
+
     return matrice;
-
-
 }
 
 float** convolve_row_major(float** matrix, float** kernel,float** output,


### PR DESCRIPTION
## Summary
- Ensure `nxn` and `kxk` free previously allocated rows and return `NULL` when `malloc` fails.
- Validate `malloc` results in `main` when allocating the output matrix and its rows, cleaning up on failure.

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a5ad41cb3c8323a96c2310c9f4787d