### PR TITLE
Normalize time difference in benchmark

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -44,6 +44,10 @@ void benchmark(float** (*fun)(float**, float**,float**, int, int),
         clock_gettime(CLOCK_MONOTONIC, &end);
         long seconds = end.tv_sec - start.tv_sec;
         long nanoseconds = end.tv_nsec - start.tv_nsec;
+        if (nanoseconds < 0) {
+            seconds--;
+            nanoseconds += 1000000000L;
+        }
         total_ms += seconds * 1000.0 + nanoseconds / 1.0e6;
     }
 


### PR DESCRIPTION
## Summary
- adjust benchmark timing to normalize when nanosecond count rolls over

## Testing
- `make`
- `./prog -r 4 2`


------
https://chatgpt.com/codex/tasks/task_e_68a5ad47b4388323b0afb27d4e5b85f0