### PR TITLE
Refactor benchmark to void return

### DIFF
--- a/main.c
+++ b/main.c
@@ -55,24 +55,30 @@ int main(int argc, char* argv[]) {
     switch (argv[1][1]) {
         case 'r':
             printf("Benchmarking row-major convolution...\n");
-            benchmark(convolve_row_major, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_row_major,
+                      matrix, kernel, output, k, out_size);
             break;
         case 'c':
             printf("Benchmarking column-major convolution...\n");
-            benchmark(convolve_col_major, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_col_major,
+                      matrix, kernel, output, k, out_size);
             break;
         case 's':
             printf("Benchmarking SIMD convolution...\n");
-            benchmark(convolve_simd, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_simd,
+                      matrix, kernel, output, k, out_size);
             break;
         case 'a':
             printf("All convolutions will be benchmarked.\n");
             printf("Benchmarking row-major convolution...\n");
-            benchmark(convolve_row_major, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_row_major,
+                      matrix, kernel, output, k, out_size);
             printf("Benchmarking column-major convolution...\n");
-            benchmark(convolve_col_major, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_col_major,
+                      matrix, kernel, output, k, out_size);
             printf("Benchmarking SIMD convolution...\n");
-            benchmark(convolve_simd, matrix, kernel, output, k, out_size);
+            benchmark((void (*)(float**, float**, float**, int, int))convolve_simd,
+                      matrix, kernel, output, k, out_size);
             break;
         default:
                 fprintf(stderr, "Usage: ./prog [-r|-c|-s|-a] <size> <kernel> \n -r: Row-major convolution \n -c: Column-major convolution \n -s: SIMD convolution \n -a: All convolutions \n");

--- a/utils.c
+++ b/utils.c
@@ -30,8 +30,8 @@ void clear_matrix(float** matrix, int n) {
     }
 }
 
-void benchmark(float** (*fun)(float**, float**,float**, int, int),
-               float** matrix, float** kernel,float** output,
+void benchmark(void (*fun)(float**, float**, float**, int, int),
+               float** matrix, float** kernel, float** output,
                int k, int out_size) {
     const int repeats = 5;
     double total_ms = 0.0;
@@ -40,7 +40,7 @@ void benchmark(float** (*fun)(float**, float**,float**, int, int),
         struct timespec start, end;
         clear_matrix(output, out_size);
         clock_gettime(CLOCK_MONOTONIC, &start);
-        output = fun(matrix, kernel, output, k, out_size);
+        fun(matrix, kernel, output, k, out_size);
         clock_gettime(CLOCK_MONOTONIC, &end);
         long seconds = end.tv_sec - start.tv_sec;
         long nanoseconds = end.tv_nsec - start.tv_nsec;

--- a/utils.h
+++ b/utils.h
@@ -4,7 +4,7 @@
 void print_matrix(float **matrix, int n);
 void free_matrix(float **matrix, int n);
 void clear_matrix(float** matrix, int n);
-void benchmark(float** (*fun) (float**, float**,float**, int, int),
-               float** matrix, float** kernel,float** output,
+void benchmark(void (*fun)(float**, float**, float**, int, int),
+               float** matrix, float** kernel, float** output,
                int k, int out_size);
 #endif


### PR DESCRIPTION
## Summary
- Update benchmark to return void and call the provided convolution function without reassigning the output pointer
- Update function pointer prototype in utils.h
- Cast convolution functions at benchmark call sites

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a5ad5029c08323955c1c500d6b3463