### PR TITLE
Use void convolution functions and simplify benchmark calls

### DIFF
--- a/main.c
+++ b/main.c
@@ -78,29 +78,29 @@ int main(int argc, char* argv[]) {
     switch (argv[1][1]) {
         case 'r':
             printf("Benchmarking row-major convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_row_major,
+            benchmark(convolve_row_major,
                       matrix, kernel, output, k, out_size);
             break;
         case 'c':
             printf("Benchmarking column-major convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_col_major,
+            benchmark(convolve_col_major,
                       matrix, kernel, output, k, out_size);
             break;
         case 's':
             printf("Benchmarking SIMD convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_simd,
+            benchmark(convolve_simd,
                       matrix, kernel, output, k, out_size);
             break;
         case 'a':
             printf("All convolutions will be benchmarked.\n");
             printf("Benchmarking row-major convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_row_major,
+            benchmark(convolve_row_major,
                       matrix, kernel, output, k, out_size);
             printf("Benchmarking column-major convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_col_major,
+            benchmark(convolve_col_major,
                       matrix, kernel, output, k, out_size);
             printf("Benchmarking SIMD convolution...\n");
-            benchmark((void (*)(float**, float**, float**, int, int))convolve_simd,
+            benchmark(convolve_simd,
                       matrix, kernel, output, k, out_size);
             break;
         default:

--- a/matrix.c
+++ b/matrix.c
@@ -57,8 +57,8 @@ float** kxk(int k) {
     return matrice;
 }
 
-float** convolve_row_major(float** matrix, float** kernel,float** output,
-                           int k,int out_size){
+void convolve_row_major(float** matrix, float** kernel, float** output,
+                        int k, int out_size){
     // Convolution (row-major)
     for (int i = 0; i < out_size; i++) {
         for (int j = 0; j < out_size; j++) {
@@ -74,12 +74,11 @@ float** convolve_row_major(float** matrix, float** kernel,float** output,
         }
     }
 
-    return output;
-    }
+}
 
 
-float** convolve_col_major(float** matrix, float** kernel,float** output,
-                           int k,int out_size){
+void convolve_col_major(float** matrix, float** kernel, float** output,
+                        int k, int out_size){
 
     // Convolution (col-major)
     for (int j = 0; j < out_size; j++) {
@@ -94,12 +93,11 @@ float** convolve_col_major(float** matrix, float** kernel,float** output,
             output[i][j] = sum;
         }
     }
-    return output;
-    }
+}
 
 
-float** convolve_simd(float** matrix, float** kernel,float** output,
-                      int k,int out_size){
+void convolve_simd(float** matrix, float** kernel, float** output,
+                   int k, int out_size){
     for (int i = 0; i < out_size; i++) {
         for (int j = 0; j < out_size; j++) {
 
@@ -133,7 +131,6 @@ float** convolve_simd(float** matrix, float** kernel,float** output,
         }
     }
 
-    return output;
 }
 
 

--- a/matrix.h
+++ b/matrix.h
@@ -4,11 +4,11 @@
 float** nxn(int n);
 float** kxk(int k);
 
-float** convolve_row_major(float** matrix, float** kernel,float** output,
-                        int k,int out_size);
-float** convolve_col_major(float** matrix, float** kernel,float** output,
-                        int k,int out_size);
-float** convolve_simd(float** matrix, float** kernel,float** output,
-                   int k,int out_size);
+void convolve_row_major(float** matrix, float** kernel, float** output,
+                        int k, int out_size);
+void convolve_col_major(float** matrix, float** kernel, float** output,
+                        int k, int out_size);
+void convolve_simd(float** matrix, float** kernel, float** output,
+                   int k, int out_size);
  
 #endif


### PR DESCRIPTION
## Summary
- Change convolution functions to return void and remove return values
- Update function prototypes and benchmark calls accordingly

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_e_68a5b2bd34808323b01e7a85106b147a