### PR TITLE
Use contiguous memory for matrix operations

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,40 +38,27 @@ int main(int argc, char* argv[]) {
     }
 
     //Initialize matrices and kernels
-    float** matrix = nxn(n);
+    float* matrix = nxn(n);
     if (!matrix) {
         fprintf(stderr, "Failed to allocate matrix.\n");
         return 1;
     }
-    float** kernel = kxk(k);
+    float* kernel = kxk(k);
     if (!kernel) {
         fprintf(stderr, "Failed to allocate kernel.\n");
-        free_matrix(matrix, n);
+        free_matrix(matrix);
         return 1;
     }
 
     int out_size = n - k + 1;
 
     // Allocation de la matrice de sortie
-    float** output = malloc(out_size * sizeof(float*));
+    float* output = malloc(out_size * out_size * sizeof(float));
     if (!output) {
         fprintf(stderr, "Failed to allocate output matrix.\n");
-        free_matrix(matrix, n);
-        free_matrix(kernel, k);
+        free_matrix(matrix);
+        free_matrix(kernel);
         return 1;
-    }
-    for (int i = 0; i < out_size; i++) {
-        output[i] = malloc(out_size * sizeof(float));
-        if (!output[i]) {
-            for (int j = 0; j < i; j++) {
-                free(output[j]);
-            }
-            free(output);
-            free_matrix(matrix, n);
-            free_matrix(kernel, k);
-            fprintf(stderr, "Failed to allocate output matrix.\n");
-            return 1;
-        }
     }
     clear_matrix(output, out_size);
 
@@ -106,17 +93,17 @@ int main(int argc, char* argv[]) {
         default:
                 fprintf(stderr, "Usage: ./prog [-r|-c|-s|-a] <size> <kernel> \n -r: Row-major convolution \n -c: Column-major convolution \n -s: SIMD convolution \n -a: All convolutions \n");
                 fprintf(stderr, "Example: ./prog -r 1024 3\n");
-                free_matrix(matrix, n);
-                free_matrix(kernel, k);
-                free_matrix(output, out_size);
+                free_matrix(matrix);
+                free_matrix(kernel);
+                free_matrix(output);
                 return 1;
     }
 
     // Free allocated memory
     printf("Freeing allocated memory...\n");
-    free_matrix(matrix, n);
-    free_matrix(kernel, k);
-    free_matrix(output, out_size);
+    free_matrix(matrix);
+    free_matrix(kernel);
+    free_matrix(output);
     return 0;
 }
 

--- a/matrix.c
+++ b/matrix.c
@@ -3,159 +3,98 @@
 #include <math.h>
 #include <immintrin.h>
 
-float** nxn(int n) {
-    float** matrice = malloc(n * sizeof(float*));
-    if (!matrice) {
+// Allocate an n x n matrix with contiguous memory
+float* nxn(int n) {
+    float* matrix = malloc(n * n * sizeof(float));
+    if (!matrix) {
         return NULL;
     }
-
-    for (int i = 0; i < n; i++) {
-        matrice[i] = malloc(n * sizeof(float));
-        if (!matrice[i]) {
-            for (int j = 0; j < i; j++) {
-                free(matrice[j]);
-            }
-            free(matrice);
-            return NULL;
-        }
-    }
-
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            matrice[i][j] = rand() / (float)RAND_MAX;
+            matrix[i * n + j] = rand() / (float)RAND_MAX;
         }
     }
-
-    return matrice;
+    return matrix;
 }
 
-float** kxk(int k) {
-    float** matrice = malloc(k * sizeof(float*));
-    if (!matrice) {
+// Allocate a k x k kernel with contiguous memory and fill with constant value
+float* kxk(int k) {
+    float* matrix = malloc(k * k * sizeof(float));
+    if (!matrix) {
         return NULL;
     }
-
-    float value = 1.0 / (k * k);
-
-    for (int i = 0; i < k; i++) {
-        matrice[i] = malloc(k * sizeof(float));
-        if (!matrice[i]) {
-            for (int j = 0; j < i; j++) {
-                free(matrice[j]);
-            }
-            free(matrice);
-            return NULL;
-        }
-    }
-
+    float value = 1.0f / (k * k);
     for (int i = 0; i < k; i++) {
         for (int j = 0; j < k; j++) {
-            matrice[i][j] = value;
+            matrix[i * k + j] = value;
         }
     }
-
-    return matrice;
+    return matrix;
 }
 
-void convolve_row_major(float** matrix, float** kernel, float** output,
-                        int k, int out_size){
-    // Convolution (row-major)
+// Row-major convolution
+void convolve_row_major(float* matrix, float* kernel, float* output,
+                        int k, int out_size) {
+    int n = out_size + k - 1;
     for (int i = 0; i < out_size; i++) {
         for (int j = 0; j < out_size; j++) {
             float sum = 0.0f;
-
-            // Parcours du kernel
             for (int ki = 0; ki < k; ki++) {
                 for (int kj = 0; kj < k; kj++) {
-                    sum += matrix[i + ki][j + kj] * kernel[ki][kj];
+                    sum += matrix[(i + ki) * n + (j + kj)] *
+                           kernel[ki * k + kj];
                 }
             }
-            output[i][j] = sum;
+            output[i * out_size + j] = sum;
         }
     }
-
 }
 
-
-void convolve_col_major(float** matrix, float** kernel, float** output,
-                        int k, int out_size){
-
-    // Convolution (col-major)
+// Column-major convolution
+void convolve_col_major(float* matrix, float* kernel, float* output,
+                        int k, int out_size) {
+    int n = out_size + k - 1;
     for (int j = 0; j < out_size; j++) {
         for (int i = 0; i < out_size; i++) {
             float sum = 0.0f;
-            // Parcours du kernel
             for (int ki = 0; ki < k; ki++) {
                 for (int kj = 0; kj < k; kj++) {
-                    sum += matrix[i + ki][j + kj] * kernel[ki][kj];
+                    sum += matrix[(i + ki) * n + (j + kj)] *
+                           kernel[ki * k + kj];
                 }
             }
-            output[i][j] = sum;
+            output[i * out_size + j] = sum;
         }
     }
 }
 
-
-void convolve_simd(float** matrix, float** kernel, float** output,
-                   int k, int out_size){
+// SIMD-optimized convolution
+void convolve_simd(float* matrix, float* kernel, float* output,
+                   int k, int out_size) {
+    int n = out_size + k - 1;
     for (int i = 0; i < out_size; i++) {
         int j = 0;
-
-        // Traiter 8 colonnes de sortie en parallèle
         for (; j <= out_size - 8; j += 8) {
             __m256 vec_sum = _mm256_setzero_ps();
-
             for (int ki = 0; ki < k; ki++) {
                 for (int kj = 0; kj < k; kj++) {
-                    __m256 mat_vals = _mm256_loadu_ps(&matrix[i + ki][j + kj]);
-                    __m256 ker_val = _mm256_set1_ps(kernel[ki][kj]);
+                    __m256 mat_vals = _mm256_loadu_ps(
+                        &matrix[(i + ki) * n + j + kj]);
+                    __m256 ker_val = _mm256_set1_ps(kernel[ki * k + kj]);
                     vec_sum = _mm256_fmadd_ps(mat_vals, ker_val, vec_sum);
                 }
             }
-
-            _mm256_storeu_ps(&output[i][j], vec_sum);
+            _mm256_storeu_ps(&output[i * out_size + j], vec_sum);
         }
-
-        // Colonnes restantes
         for (; j < out_size; j++) {
             float sum = 0.0f;
             for (int ki = 0; ki < k; ki++) {
                 for (int kj = 0; kj < k; kj++) {
-                    sum += matrix[i + ki][j + kj] * kernel[ki][kj];
+                    sum += matrix[(i + ki) * n + (j + kj)] *
+                           kernel[ki * k + kj];
                 }
             }
-            output[i][j] = sum;
+            output[i * out_size + j] = sum;
         }
     }
 }
-
-
-/*  
-    // Convolution (SIMD)
-    for (int i = 0; i < out_size; i++) {
-        for (int j = 0; j < out_size; j++) {
-            __m256 sum = _mm256_setzero_ps(); // Initialisation du registre SIMD
-            
-            // Parcours du kernel
-            for (int ki = 0; ki < k; ki++) {
-                for (int kj = 0; kj < k; kj += 8) {
-                    // Chargement des valeurs du kernel et de la matrice dans des registres SIMD
-                    __m256 kernel_values = _mm256_loadu_ps(&kernel[ki][kj]);
-                    __m256 matrix_values = _mm256_loadu_ps(&matrix[i + ki][j + kj]);
-                    
-                    // Multiplication et accumulation
-                    sum = _mm256_add_ps(sum, _mm256_mul_ps(matrix_values, kernel_values));
-                }
-            }
-            // Réduction des valeurs SIMD en une seule valeur
-            float result[8];
-            _mm256_storeu_ps(result, sum);
-            float final_sum = 0.0f;
-            for (int r = 0; r < 8; r++) {
-                final_sum += result[r];
-            }
-            output[i][j] = final_sum;
-        }
-    }
-    return output;
-*/

--- a/matrix.h
+++ b/matrix.h
@@ -1,14 +1,14 @@
 #ifndef MATRICE_H
 #define MATRICE_H
 
-float** nxn(int n);
-float** kxk(int k);
+float* nxn(int n);
+float* kxk(int k);
 
-void convolve_row_major(float** matrix, float** kernel, float** output,
+void convolve_row_major(float* matrix, float* kernel, float* output,
                         int k, int out_size);
-void convolve_col_major(float** matrix, float** kernel, float** output,
+void convolve_col_major(float* matrix, float* kernel, float* output,
                         int k, int out_size);
-void convolve_simd(float** matrix, float** kernel, float** output,
+void convolve_simd(float* matrix, float* kernel, float* output,
                    int k, int out_size);
  
 #endif

--- a/utils.c
+++ b/utils.c
@@ -6,32 +6,29 @@
 
 #include "matrix.h"
 
-void print_matrix(float **matrix, int n) {
+void print_matrix(float *matrix, int n) {
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            printf("%f ", matrix[i][j]);
+            printf("%f ", matrix[i * n + j]);
         }
         printf("\n");
     }
 }
 
-void free_matrix(float** matrix, int n) {
-    for (int i = 0; i < n; i++) {
-        free(matrix[i]);
-    }
+void free_matrix(float *matrix) {
     free(matrix);
 }
 
-void clear_matrix(float** matrix, int n) {
+void clear_matrix(float *matrix, int n) {
     for (int i = 0; i < n; i++) {
         for (int j = 0; j < n; j++) {
-            matrix[i][j] = 0.0f;
+            matrix[i * n + j] = 0.0f;
         }
     }
 }
 
-void benchmark(void (*fun)(float**, float**, float**, int, int),
-               float** matrix, float** kernel, float** output,
+void benchmark(void (*fun)(float*, float*, float*, int, int),
+               float* matrix, float* kernel, float* output,
                int k, int out_size) {
     const int repeats = 5;
     double total_ms = 0.0;

--- a/utils.h
+++ b/utils.h
@@ -1,10 +1,10 @@
 #ifndef UTILS_H
 #define UTILS_H
 
-void print_matrix(float **matrix, int n);
-void free_matrix(float **matrix, int n);
-void clear_matrix(float** matrix, int n);
-void benchmark(void (*fun)(float**, float**, float**, int, int),
-               float** matrix, float** kernel, float** output,
+void print_matrix(float *matrix, int n);
+void free_matrix(float *matrix);
+void clear_matrix(float *matrix, int n);
+void benchmark(void (*fun)(float*, float*, float*, int, int),
+               float* matrix, float* kernel, float* output,
                int k, int out_size);
 #endif


### PR DESCRIPTION
## Summary
- allocate matrices and kernels with single contiguous `malloc` blocks
- index matrices via 1D offsets to exploit contiguous layout
- update convolution, utility, and main routines for new layout

## Testing
- `make clean && make`
- `./prog -r 4 3`
- `./prog -c 4 3`
- `./prog -s 8 3`


------
https://chatgpt.com/codex/tasks/task_e_68a5b699c7b483239f3995e8df5615f5