### PR TITLE
Add detailed runtime stats to benchmarks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ CFLAGS=-O3 -march=native -std=c11 -Wall -Wextra
 OBJ=main.o matrix.o utils.o
 
 prog: $(OBJ)
->$(CC) $(CFLAGS) -o $@ $(OBJ)
+>$(CC) $(CFLAGS) -o $@ $(OBJ) -lm
 
 %.o: %.c
 >$(CC) $(CFLAGS) -c $< -o $@

--- a/utils.c
+++ b/utils.c
@@ -31,6 +31,7 @@ void benchmark(void (*fun)(float*, float*, float*, int, int),
                float* matrix, float* kernel, float* output,
                int k, int out_size) {
     const int repeats = 5;
+    double times_ms[repeats];
     double total_ms = 0.0;
 
     for (int r = 0; r < repeats; r++) {
@@ -45,9 +46,23 @@ void benchmark(void (*fun)(float*, float*, float*, int, int),
             seconds--;
             nanoseconds += 1000000000L;
         }
-        total_ms += seconds * 1000.0 + nanoseconds / 1.0e6;
+        times_ms[r] = seconds * 1000.0 + nanoseconds / 1.0e6;
+        total_ms += times_ms[r];
     }
 
-    printf("Average runtime over %d runs: %.3f ms.\n",
-           repeats, total_ms / repeats);
+    double average = total_ms / repeats;
+    double variance = 0.0;
+    for (int r = 0; r < repeats; r++) {
+        double diff = times_ms[r] - average;
+        variance += diff * diff;
+    }
+    variance /= repeats;
+    double stddev = sqrt(variance);
+
+    printf("Average runtime over %d runs: %.3f ms\n", repeats, average);
+    printf("Standard deviation: %.3f ms\n", stddev);
+
+    double pixels = (double)out_size * out_size;
+    double throughput = pixels / (average / 1000.0);
+    printf("Throughput: %.2f pixels/s\n", throughput);
 }


### PR DESCRIPTION
## Summary
- capture individual iteration times in `benchmark`
- compute and print mean, standard deviation, and pixel throughput
- link math library for `sqrt`

## Testing
- `make`
- `./prog -r 4 3`


------
https://chatgpt.com/codex/tasks/task_e_68a5b794c5fc83238a5c0f70a9d2cb0c