### PR TITLE
Capture runtime variance and plot error bars

### DIFF
--- a/plot_results.py
+++ b/plot_results.py
@@ -11,29 +11,38 @@ if len(sys.argv) != 2:
 csv_path = sys.argv[1]
 
 data = defaultdict(dict)
+errors = defaultdict(dict)
 with open(csv_path) as f:
     reader = csv.DictReader(f)
     for row in reader:
         size = int(row['size'])
         try:
             time_ms = float(row['time_ms'])
+            std_ms = float(row.get('std_ms', 0.0))
         except ValueError:
-            print(f"Warning: skipping row with non-numeric time_ms={row['time_ms']!r}", file=sys.stderr)
+            print(
+                f"Warning: skipping row with non-numeric values {row}",
+                file=sys.stderr,
+            )
             continue
         data[size][row['version']] = time_ms
+        errors[size][row['version']] = std_ms
 
 sizes = sorted(data.keys())
 row = [data[n].get('r', 0) for n in sizes]
+row_err = [errors[n].get('r', 0) for n in sizes]
 col = [data[n].get('c', 0) for n in sizes]
+col_err = [errors[n].get('c', 0) for n in sizes]
 simd = [data[n].get('s', 0) for n in sizes]
+simd_err = [errors[n].get('s', 0) for n in sizes]
 
 plt.figure()
-plt.plot(sizes, row, marker='o', label='row-major')
-plt.plot(sizes, col, marker='o', label='col-major')
-plt.plot(sizes, simd, marker='o', label='SIMD')
+plt.errorbar(sizes, row, yerr=row_err, marker='o', label='row-major')
+plt.errorbar(sizes, col, yerr=col_err, marker='o', label='col-major')
+plt.errorbar(sizes, simd, yerr=simd_err, marker='o', label='SIMD')
 plt.xlabel('Matrix size N')
-plt.ylabel('Avg runtime (ms)')
-plt.title('Convolution runtime comparison')
-plt.legend()
+plt.ylabel('Average runtime (ms)')
+plt.title('Convolution runtime comparison\n(error bars = std dev across runs)')
+plt.legend(title='Variant')
 plt.grid(True)
 plt.savefig('runtimes.png')


### PR DESCRIPTION
## Summary
- Record runtime mean and standard deviation by repeating each configuration and writing the results to `results.csv`.
- Read variance columns and add error-bar plots with clearer labels indicating standard deviation across runs.

## Testing
- `bash make_plots.sh` *(fails: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b8a1c9088323affb5928155bb45e