### PR TITLE
Combine kernel plots into single image and log progress

### DIFF
--- a/make_plots.sh
+++ b/make_plots.sh
@@ -1,29 +1,38 @@
 #!/bin/bash
 set -e
+export LC_NUMERIC=C
 
 # Build program
 make clean >/dev/null 2>&1 || true
 make >/dev/null
 
 sizes=(256 512 1024 2048)
-k=8
+ks=(3 5 8 10)
 runs=3
-out_file="results.csv"
+csv_files=()
 
-# Write CSV header
-printf "size,version,time_ms,std_ms\n" > "$out_file"
+for k in "${ks[@]}"; do
+  echo "Kernel size k=$k"
+  out_file="results_k${k}.csv"
+  csv_files+=("$out_file")
+  # Write CSV header
+  printf "size,version,time_ms,std_ms\n" > "$out_file"
 
-for n in "${sizes[@]}"; do
-  for v in r c s; do
-    times=()
-    for ((i=0; i<runs; i++)); do
-      line=$(./prog -$v $n $k | grep 'Average runtime')
-      times+=("$(echo "$line" | awk '{print $(NF-1)}')")
+  for n in "${sizes[@]}"; do
+    echo "  Matrix size N=$n"
+    for v in r c s; do
+      echo "    Variant $v"
+      times=()
+      for ((i=0; i<runs; i++)); do
+        echo "      Run $((i+1))/$runs"
+        line=$(./prog -$v $n $k | grep 'Average runtime')
+        times+=("$(echo "$line" | awk '{print $(NF-1)}')")
+      done
+      mean=$(printf "%s\n" "${times[@]}" | awk '{s+=$1} END {printf "%.3f", s/NR}')
+      std=$(printf "%s\n" "${times[@]}" | awk -v m="$mean" '{s+=($1-m)^2} END {printf "%.3f", sqrt(s/NR)}')
+      printf "%s,%s,%s,%s\n" "$n" "$v" "$mean" "$std" >> "$out_file"
     done
-    mean=$(printf "%s\n" "${times[@]}" | awk '{s+=$1} END {print s/NR}')
-    std=$(printf "%s\n" "${times[@]}" | awk -v m="$mean" '{s+=($1-m)^2} END {print sqrt(s/NR)}')
-    printf "%s,%s,%.3f,%.3f\n" "$n" "$v" "$mean" "$std" >> "$out_file"
   done
 done
 
-python3 plot_results.py "$out_file"
+python3 plot_results.py "${csv_files[@]}"

--- a/plot_results.py
+++ b/plot_results.py
@@ -1,48 +1,69 @@
 #!/usr/bin/env python3
 import csv
 import sys
+import os
+import math
 from collections import defaultdict
 import matplotlib.pyplot as plt
+import re
 
-if len(sys.argv) != 2:
-    print("Usage: plot_results.py results.csv")
+if len(sys.argv) < 2:
+    print("Usage: plot_results.py results.csv [results2.csv ...]")
     sys.exit(1)
 
-csv_path = sys.argv[1]
+csv_paths = sys.argv[1:]
+num = len(csv_paths)
+cols = min(2, num)
+rows = int(math.ceil(num / cols))
+fig, axes = plt.subplots(rows, cols, figsize=(6 * cols, 4 * rows))
 
-data = defaultdict(dict)
-errors = defaultdict(dict)
-with open(csv_path) as f:
-    reader = csv.DictReader(f)
-    for row in reader:
-        size = int(row['size'])
-        try:
-            time_ms = float(row['time_ms'])
-            std_ms = float(row.get('std_ms', 0.0))
-        except ValueError:
-            print(
-                f"Warning: skipping row with non-numeric values {row}",
-                file=sys.stderr,
-            )
-            continue
-        data[size][row['version']] = time_ms
-        errors[size][row['version']] = std_ms
+if num == 1:
+    axes = [axes]
+else:
+    axes = axes.flatten()
 
-sizes = sorted(data.keys())
-row = [data[n].get('r', 0) for n in sizes]
-row_err = [errors[n].get('r', 0) for n in sizes]
-col = [data[n].get('c', 0) for n in sizes]
-col_err = [errors[n].get('c', 0) for n in sizes]
-simd = [data[n].get('s', 0) for n in sizes]
-simd_err = [errors[n].get('s', 0) for n in sizes]
+for ax, csv_path in zip(axes, csv_paths):
+    data = defaultdict(dict)
+    errors = defaultdict(dict)
+    with open(csv_path) as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            size = int(row['size'])
+            try:
+                time_ms = float(row['time_ms'])
+                std_ms = float(row.get('std_ms', 0.0))
+            except ValueError:
+                print(
+                    f"Warning: skipping row with non-numeric values {row}",
+                    file=sys.stderr,
+                )
+                continue
+            data[size][row['version']] = time_ms
+            errors[size][row['version']] = std_ms
 
-plt.figure()
-plt.errorbar(sizes, row, yerr=row_err, marker='o', label='row-major')
-plt.errorbar(sizes, col, yerr=col_err, marker='o', label='col-major')
-plt.errorbar(sizes, simd, yerr=simd_err, marker='o', label='SIMD')
-plt.xlabel('Matrix size N')
-plt.ylabel('Average runtime (ms)')
-plt.title('Convolution runtime comparison\n(error bars = std dev across runs)')
-plt.legend(title='Variant')
-plt.grid(True)
+    sizes = sorted(data.keys())
+    row = [data[n].get('r', 0) for n in sizes]
+    row_err = [errors[n].get('r', 0) for n in sizes]
+    col = [data[n].get('c', 0) for n in sizes]
+    col_err = [errors[n].get('c', 0) for n in sizes]
+    simd = [data[n].get('s', 0) for n in sizes]
+    simd_err = [errors[n].get('s', 0) for n in sizes]
+
+    ax.errorbar(sizes, row, yerr=row_err, marker='o', label='row-major')
+    ax.errorbar(sizes, col, yerr=col_err, marker='o', label='col-major')
+    ax.errorbar(sizes, simd, yerr=simd_err, marker='o', label='SIMD')
+    ax.set_xlabel('Matrix size N')
+    ax.set_ylabel('Average runtime (ms)')
+
+    base = os.path.basename(csv_path)
+    m = re.search(r'k(\d+)', base)
+    k_label = f"k={m.group(1)} " if m else ""
+    ax.set_title(f'{k_label}Convolution runtime')
+    ax.legend(title='Variant')
+    ax.grid(True)
+
+for ax in axes[len(csv_paths):]:
+    ax.set_visible(False)
+
+plt.tight_layout()
 plt.savefig('runtimes.png')


### PR DESCRIPTION
## Summary
- Add progress `echo` statements to nested loops in `make_plots.sh`
- Accumulate results for multiple kernel sizes and generate one `runtimes.png`
- Extend `plot_results.py` to accept several CSV files and plot them as subplots

## Testing
- `make clean && make`
- `./make_plots.sh` *(fails: ModuleNotFoundError: No module named 'matplotlib')*


------
https://chatgpt.com/codex/tasks/task_e_68a5be3d8bd48323b04bd7902b6e5836